### PR TITLE
Show the popup only in Chinese pages

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -106,6 +106,13 @@
 						the page if you zoom in">[?]</span>
 					</td>
 				</tr>
+				<tr>
+					<td>
+						<input class="config" type="checkbox" id="showOnlyInChinesePage" name="scaleOnZoom">Show popup only in Chinese pages</input>
+						<span tooltip="If enabled, the popup will only show if the browser detects
+						Chinese in the current page, excluding Japanese or Korean.">[?]</span>
+					</td>
+				</tr>
 			</table>
 		</div>
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -17,7 +17,12 @@ chrome.runtime.onMessage.addListener(
 		switch(request.type) {
 			case 'enable?':
                 //chrome.tabs.sendMessage(sender.tab.id, {"type":"config", "config": liuChan.config.content});
-				if (request.enabled === false && liuChan.enabled) liuChan.onTabSelect(sender.tab);
+				// NOTE:
+				// `liuChan.onTabSelect()` handles the logic 
+				// to check if the content script should be enabled, based on the detected language of the current page.
+				// Therefore `liuChan.onTabSelect()` should be invoked regardless of `liuChan.enabled`.
+				// if (request.enabled === false && liuChan.enabled) liuChan.onTabSelect(sender.tab);
+				if (request.enabled === false) liuChan.onTabSelect(sender.tab);
 				break;
 			case 'xsearch':
 				let e = liuChan.dict.wordSearch(liuChan.dict.hanzi, request.text);

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -18,12 +18,17 @@ class Dictionary {
     }
 
     onDictionaryLoaded(tab) {
-        // Activate tab and send along content script related settings
-		if (this.lc.config.displayHelp === true && !this.lc.config.content.disableKeys) {
-            chrome.tabs.sendMessage(tab[0].id, {"type":"enable", "config": this.lc.config.content, "displayHelp": this.lc.displayHelp});
-		} else {
-            chrome.tabs.sendMessage(tab[0].id, {"type": "enable", "config": this.lc.config.content});
-        }
+        // Enable content script only if the detected language is Chinese.
+        chrome.tabs.detectLanguage(tab.id, (language) => {
+            if (!this.lc.config.content.showOnlyInChinesePage || language === "zh-CN" || language === "zh-TW") {
+                // Activate tab and send along content script related settings
+                if (this.lc.config.displayHelp === true && !this.lc.config.content.disableKeys) {
+                    chrome.tabs.sendMessage(tab[0].id, {"type":"enable", "config": this.lc.config.content, "displayHelp": this.lc.displayHelp});
+                } else {
+                    chrome.tabs.sendMessage(tab[0].id, {"type": "enable", "config": this.lc.config.content});
+                }
+            }
+        })
     }
 
     async checkForUpdates() {

--- a/src/js/liuchan.js
+++ b/src/js/liuchan.js
@@ -89,6 +89,7 @@ class LiuChan {
                 highlightText: true,
                 highlightInput: false,
                 scaleOnZoom: true,
+                showOnlyInChinesePage: false,
                 showOnKey: 0,
                 disableKeys: false
             },
@@ -263,12 +264,16 @@ class LiuChan {
 	// The callback for chrome.tabs.onActivated
 	// Sends a message to the tab to enable itself if it hasn't
 	onTabSelect(tab) {
-		if (this.enabled) {
-            chrome.tabs.sendMessage(tab.tabId ? tab.tabId : tab.id, {
-				"type":"enable",
-				"config":this.config.content
-			});
-		}
+        // Enable content script only if the detected language is Chinese.
+        chrome.tabs.detectLanguage(tab.id, (language) => {
+            if (this.enabled && 
+                (!this.config.content.showOnlyInChinesePage || language === "zh-CN" || language === "zh-TW")) {
+                chrome.tabs.sendMessage(tab.tabId ? tab.tabId : tab.id, {
+                    "type":"enable",
+                    "config":this.config.content
+                });
+            }
+        });
         chrome.tabs.sendMessage(tab.tabId ? tab.tabId : tab.id, {
             "type":"update",
             "notepad":this.config.notepad

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -64,6 +64,7 @@ function init() {
         checkboxUsePinyinToneColors: d.getElementById('usePinyinToneColors'),
         checkboxDisplayHelp: d.getElementById('displayHelp'),
         checkboxScaleOnZoom: d.getElementById('scaleOnZoom'),
+        checkboxShowOnlyInChinesePage: d.getElementById('showOnlyInChinesePage'),
         selectLineEnding: d.getElementById('lineEnding'),
         selectCopySeparator: d.getElementById('copySeparator'),
         inputMaxCopyEntries: d.getElementById('maxClipCopyEntries'),
@@ -104,6 +105,7 @@ function saveOptions() {
             highlightText: e.checkboxHighlightText.checked,
             highlightInput: e.checkboxHighlightInput.checked,
             scaleOnZoom: e.checkboxScaleOnZoom.checked,
+            showOnlyInChinesePage: e.checkboxShowOnlyInChinesePage.checked,
             showOnKey: parseInt(document.querySelector('input[name="showOnKey"]:checked').value),
             disableKeys: e.checkboxDisableKeys.checked
         },
@@ -166,6 +168,7 @@ function restoreOptions() {
             e.checkboxHighlightText.checked = items.content.highlightText;
             e.checkboxHighlightInput.checked = items.content.highlightInput;
             e.checkboxScaleOnZoom.checked = items.content.scaleOnZoom;
+            e.checkboxShowOnlyInChinesePage.checked = items.content.showOnlyInChinesePage;
             // showOnKey radio button - see below
             e.checkboxDisableKeys.checked = items.content.disableKeys;
 


### PR DESCRIPTION
Hi there, first of all thanks so much for creating this wonderful extension!

As a Mandarin learner myself it has been a great experience using LiuChan, but I sometimes find it inconvenient how the popup shows up even on websites in Japanese, because of the overlap between many Hanzi/Kanji characters.

This PR comes with an option (disabled by default) that uses Chrome API to [detect language](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-detectLanguage) of the current page, and disables the content script if the language code is neither `zh-CN` nor `zh-TW`.

I understand this is no longer actively developed, but it'd be great if you could merge this - it'll be really helpful for Japanese (or Korean) readers!

Also here's some screenshots:

https://github.com/Paperfeed/LiuChan/assets/28210288/bfc74014-7070-4ffd-b779-dd6ec9948761